### PR TITLE
Feature add support for logger

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -118,7 +118,7 @@ func (h queueLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		logger = &responseLogger{w: w}
 	}
 	h.handler.ServeHTTP(logger, req)
-	h.logger.Info(buildCommonLogLine(req, t, logger.Status(), logger.Size()))
+	h.logger.Info(string(buildCommonLogLine(req, t, logger.Status(), logger.Size()))
 }
 
 type loggingResponseWriter interface {

--- a/handlers.go
+++ b/handlers.go
@@ -110,6 +110,7 @@ func (h forwardedLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Requ
 }
 
 func (h queueLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	t := time.Now()
 	var logger loggingResponseWriter
 	if _, ok := w.(http.Hijacker); ok {
 		logger = &hijackLogger{responseLogger: responseLogger{w: w}}
@@ -117,7 +118,7 @@ func (h queueLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		logger = &responseLogger{w: w}
 	}
 	h.handler.ServeHTTP(logger, req)
-	h.logger.Infof("req: %v status: %v, size: %v", req, logger.Status(), logger.Size())
+	h.logger.Info(buildCommonLogLine(req, t, logger.Status(), logger.Size()))
 }
 
 type loggingResponseWriter interface {

--- a/handlers.go
+++ b/handlers.go
@@ -118,7 +118,7 @@ func (h queueLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		logger = &responseLogger{w: w}
 	}
 	h.handler.ServeHTTP(logger, req)
-	h.logger.Info(string(buildCommonLogLine(req, t, logger.Status(), logger.Size()))
+	h.logger.Info(string(buildCommonLogLine(req, t, logger.Status(), logger.Size())))
 }
 
 type loggingResponseWriter interface {

--- a/handlers.go
+++ b/handlers.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/monsooncommerce/log"
 )
 
 // MethodHandler is an http.Handler that dispatches to a handler whose key in the MethodHandler's
@@ -66,6 +68,11 @@ type forwardedLoggingHandler struct {
 	handler http.Handler
 }
 
+type queueLoggingHandler struct {
+	logger  *log.Log
+	handler http.Handler
+}
+
 func (h loggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	t := time.Now()
 	var logger loggingResponseWriter
@@ -100,6 +107,17 @@ func (h forwardedLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Requ
 	}
 	h.handler.ServeHTTP(logger, req)
 	writeForwardedLog(h.writer, req, t, logger.Status(), logger.Size())
+}
+
+func (h queueLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	var logger loggingResponseWriter
+	if _, ok := w.(http.Hijacker); ok {
+		logger = &hijackLogger{responseLogger: responseLogger{w: w}}
+	} else {
+		logger = &responseLogger{w: w}
+	}
+	h.handler.ServeHTTP(logger, req)
+	h.logger.Infof("req: %v status: %v, size: %v", req, logger.Status(), logger.Size())
 }
 
 type loggingResponseWriter interface {
@@ -314,4 +332,8 @@ func LoggingHandler(out io.Writer, h http.Handler) http.Handler {
 
 func ForwardedLoggingHandler(out io.Writer, h http.Handler) http.Handler {
 	return forwardedLoggingHandler{out, h}
+}
+
+func QueueLoggingHandler(log *log.Log, h http.Handler) http.Handler {
+	return queueLoggingHandler{log, h}
 }


### PR DESCRIPTION
In effort to fix the log format of the lines that were previously going to the access log file (which weren't going through the logger (only the stompWriter)), this adds a new logforwarderhandler type of struct called queueLoggingHandler, which satisfies the http.Server interface but logs to logger rather than file