### PR TITLE
change log level to debug from info.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -142,7 +142,7 @@ func (h queueLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		logger = &responseLogger{w: w}
 	}
 	h.handler.ServeHTTP(logger, req)
-	h.logger.Info(string(buildCommonLogLine(req, t, logger.Status(), logger.Size())))
+	h.logger.Debug(string(buildCommonLogLine(req, t, logger.Status(), logger.Size())))
 }
 
 type loggingResponseWriter interface {


### PR DESCRIPTION
for queuelog handler, do debug log instead of info to keep prod healthy